### PR TITLE
make benchmark more realistic

### DIFF
--- a/cohttp-lwt-unix/cohttp_lwt_unix.ml
+++ b/cohttp-lwt-unix/cohttp_lwt_unix.ml
@@ -8,14 +8,11 @@ module BenchmarkServer = struct
       let open Lwt in
       let open Cohttp_lwt_unix in
       let uri = Request.uri req in
+      Lwt_unix.yield () >>= fun () ->
       match Uri.path uri with
-      | "/" ->
-        Lwt_unix.yield () >>= fun () ->
-        Server.respond_string ~headers ~status:`OK ~body:text ()
+      | "/" -> Server.respond_string ~headers ~status:`OK ~body:text ()
       | "/exit" -> exit 0
-      | _   ->
-        Lwt_unix.yield () >>= fun () ->
-        Server.respond_not_found ()
+      | _   -> Server.respond_not_found ()
     in
     handler
   ;;

--- a/cohttp-lwt-unix/cohttp_lwt_unix.ml
+++ b/cohttp-lwt-unix/cohttp_lwt_unix.ml
@@ -5,12 +5,17 @@ module BenchmarkServer = struct
   let benchmark =
     let headers = Cohttp.Header.of_list ["content-length", Int.to_string (String.length text)] in
     let handler _conn req _body =
+      let open Lwt in
       let open Cohttp_lwt_unix in
       let uri = Request.uri req in
       match Uri.path uri with
-      | "/" -> Server.respond_string ~headers ~status:`OK ~body:text ()
+      | "/" ->
+        Lwt_unix.yield () >>= fun () ->
+        Server.respond_string ~headers ~status:`OK ~body:text ()
       | "/exit" -> exit 0
-      | _   -> Server.respond_not_found ()
+      | _   ->
+        Lwt_unix.yield () >>= fun () ->
+        Server.respond_not_found ()
     in
     handler
   ;;

--- a/httpaf-effects/httpaf_effects.ml
+++ b/httpaf-effects/httpaf_effects.ml
@@ -32,7 +32,7 @@ let create_connection_handler ?config request_handler =
             end;
             reader_thread ()
         | `Yield       -> 
-            let tid = if debug then Aeio.get_tid () else 0xC0FFEE in
+            (* let tid = if debug then Aeio.get_tid () else 0xC0FFEE in *)
             let iv = Aeio.IVar.create () in
             Server_connection.yield_reader conn (fun () ->
               Aeio.IVar.fill iv ());
@@ -59,7 +59,7 @@ let create_connection_handler ?config request_handler =
           end;
           writer_thread ()
         | `Yield        -> 
-            let tid = if debug then Aeio.get_tid () else 0xC0FFEE in
+            (* let tid = if debug then Aeio.get_tid () else 0xC0FFEE in *)
             let iv = Aeio.IVar.create () in
             Server_connection.yield_writer conn (fun () ->
               Aeio.IVar.fill iv ());

--- a/httpaf-effects/wrk_effects_benchmark.ml
+++ b/httpaf-effects/wrk_effects_benchmark.ml
@@ -21,26 +21,23 @@ let text = Bigstringaf.of_string ~off:0 ~len:(String.length text) text
 let headers = Headers.of_list ["content-length", string_of_int (Bigstringaf.length text)]
 let request_handler reqd =
   let request = Reqd.request reqd in
-    let response_body =
-      match request.Request.target with
-      | "/" ->
-        let response_ok = Response.create ~headers `OK in
-          Reqd.respond_with_bigstring reqd response_ok text
-      | "/exit" ->
-          exit 0
-      | _   ->
-        let response_nf = Response.create `Not_found in
-          Reqd.respond_with_string reqd response_nf "Route not found"
-    in
-     ()
+  match request.Request.target with
+  | "/" ->
+    let response_ok = Response.create ~headers `OK in
+    Reqd.respond_with_bigstring reqd response_ok text
+  | "/exit" ->
+      exit 0
+  | _   ->
+    let response_nf = Response.create `Not_found in
+    Reqd.respond_with_string reqd response_nf "Route not found"
 
-let main port max_accepts_per_batch () =
-  let rec looper () =
+let main port _max_accepts_per_batch () =
+  (* let rec looper () =
     Aeio.sleep 1.0;
     Printf.printf "Live asyncs=%d\n%!" @@ Aeio.live_async ();
     looper ()
   in
-(*   ignore @@ Aeio.async looper (); *)
+  ignore @@ Aeio.async looper (); *)
   (* Server listens on localhost at 8080 *)
   let addr, port = Unix.inet_addr_loopback, port in
   printf "Echo server listening on 127.0.0.1:%d\n%!" port;
@@ -70,5 +67,5 @@ let main port max_accepts_per_batch () =
 
 let _ = 
   try Aeio.run ~engine:`Libev (main 8080 128) 
-  with e -> ()
+  with _e -> ()
     

--- a/httpaf-lwt/httpaf_lwt.ml
+++ b/httpaf-lwt/httpaf_lwt.ml
@@ -14,10 +14,14 @@ module BenchmarkServer = struct
       let { Request.target; _ } = Reqd.request reqd in
       let request_body          = Reqd.request_body reqd in
       Body.close_reader request_body;
-      match target with
+      let open Lwt in
+      Lwt.async @@ fun () ->
+      Lwt_unix.yield () >>= fun () ->
+      (match target with
       | "/" -> Reqd.respond_with_bigstring reqd (Response.create ~headers `OK) text;
       | "/exit" -> Caml.exit 0;
-      | _   -> Reqd.respond_with_string    reqd (Response.create `Not_found) "Route not found"
+      | _   -> Reqd.respond_with_string    reqd (Response.create `Not_found) "Route not found");
+      Lwt.return_unit
     in
     handler
   ;;

--- a/nethttp-go/httpserv.go
+++ b/nethttp-go/httpserv.go
@@ -3,10 +3,12 @@ package main
 import (
         "fmt"
         "net/http"
+        "runtime"
 )
 
 func handler(w http.ResponseWriter, r *http.Request) {
         const text = "CHAPTER I. Down the Rabbit-Hole  Alice was beginning to get very tired of sitting by her sister on the bank, and of having nothing to do: once or twice she had peeped into the book her sister was reading, but it had no pictures or conversations in it, <and what is the use of a book,> thought Alice <without pictures or conversations?> So she was considering in her own mind (as well as she could, for the hot day made her feel very sleepy and stupid), whether the pleasure of making a daisy-chain would be worth the trouble of getting up and picking the daisies, when suddenly a White Rabbit with pink eyes ran close by her. There was nothing so very remarkable in that; nor did Alice think it so very much out of the way to hear the Rabbit say to itself, <Oh dear! Oh dear! I shall be late!> (when she thought it over afterwards, it occurred to her that she ought to have wondered at this, but at the time it all seemed quite natural); but when the Rabbit actually took a watch out of its waistcoat-pocket, and looked at it, and then hurried on, Alice started to her feet, for it flashed across her mind that she had never before seen a rabbit with either a waistcoat-pocket, or a watch to take out of it, and burning with curiosity, she ran across the field after it, and fortunately was just in time to see it pop down a large rabbit-hole under the hedge. In another moment down went Alice after it, never once considering how in the world she was to get out again. The rabbit-hole went straight on like a tunnel for some way, and then dipped suddenly down, so suddenly that Alice had not a moment to think about stopping herself before she found herself falling down a very deep well. Either the well was very deep, or she fell very slowly, for she had plenty of time as she went down to look about her and to wonder what was going to happen next. First, she tried to look down and make out what she was coming to, but it was too dark to see anything; then she looked at the sides of the well, and noticed that they were filled with cupboards......"
+        runtime.Gosched()
         fmt.Fprintf(w, text)
 }
 


### PR DESCRIPTION
This change is based on https://github.com/inhabitedtype/httpaf/issues/200
in which @vouillon reasonably points out that it is unrealistic to assume that the request handler responds immediately. The benchmark is modified to yield inside the request handler in order to simulate the effect of a hypothetical db request.

This makes the behaviour slightly different from the other benchmarks, but maybe it is worth letting all of them yield on handling the requests.

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>