### PR TITLE
add version bound for shuttle

### DIFF
--- a/setup_opams.sh
+++ b/setup_opams.sh
@@ -11,4 +11,4 @@ opam pin -n aeio git+https://github.com/kayceesrk/ocaml-aeio.git
 opam install -y conf-libev httpaf lwt dune aeio
 
 opam switch create 4.12.0
-opam install -y conf-libev lwt core httpaf httpaf-lwt-unix cohttp-lwt-unix shuttle httpaf async
+opam install -y conf-libev lwt core httpaf httpaf-lwt-unix cohttp-lwt-unix shuttle.0.3.1 httpaf async


### PR DESCRIPTION
I'm hoping to make a couple of breaking changes in shuttle as I make progress on my http 1.1 server implementation. This version bound should keep these benchmarks building as I cut new shuttle releases.