### PR TITLE
cohttp-eio/httaf: update to latest

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,5 +8,5 @@
   branch = effects
 [submodule "cohttp-eio/ocaml-cohttp"]
 	path = cohttp-eio/vendor/ocaml-cohttp
-	url = https://github.com/bikallem/ocaml-cohttp.git
-	branch = eio-3
+  url = https://github.com/mirage/ocaml-cohttp.git
+	branch = master

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@ IMAGES = cohttp-eio \
 
 BUILD=./build
 
+# nc is --no-cache option sent to docker build
+# use is like make nc=--no-cache-build cohttp-eio
+# 
 run: build
 	mkdir -p output
 	docker create --name $(retro)-tmp $(retro)

--- a/cohttp-eio/Dockerfile
+++ b/cohttp-eio/Dockerfile
@@ -1,8 +1,8 @@
 # Build cohttp_eio.exe
-FROM ocaml/opam:debian-11-ocaml-4.12-domains AS cohttp-eio
-RUN (cd opam-repository && git pull origin 75f69f2010f203d29adb423858f93bf4406c7869 && opam update)
+FROM ocaml/opam:debian-11-ocaml-5.0 AS cohttp-eio
 WORKDIR /src
-RUN opam depext -i ppx_cstruct dune fmt logs cstruct faraday mtime optint lwt-dllist psq luv luv_unix uri ppx_sexp_conv eio_main base64 re sexplib0 ppx_sexp_conv stringext fmt uri-sexp
+RUN sudo apt-get install -qq -yy pkg-config file
+RUN opam depext -i dune eio_main.0.6 mdx uri fmt odoc
 COPY --chown=opam . /src
 RUN sudo chown opam .
 RUN opam exec -- dune build --profile=release

--- a/cohttp-eio/Dockerfile
+++ b/cohttp-eio/Dockerfile
@@ -1,8 +1,9 @@
 # Build cohttp_eio.exe
-FROM ocaml/opam:debian-11-ocaml-5.0 AS cohttp-eio
+FROM ocaml/opam:debian-11-ocaml-5.1 AS cohttp-eio
 WORKDIR /src
 RUN sudo apt-get install -qq -yy pkg-config file
-RUN opam depext -i dune eio_main.0.6 mdx uri fmt odoc
+RUN opam switch reinstall
+RUN opam depext -i dune eio_main.0.6 mdx uri fmt
 COPY --chown=opam . /src
 RUN sudo chown opam .
 RUN opam exec -- dune build --profile=release

--- a/http-async/Dockerfile
+++ b/http-async/Dockerfile
@@ -1,6 +1,7 @@
 FROM ocaml/opam:debian-11-ocaml-4.12
 RUN sudo ln -f /usr/bin/opam-2.1 /usr/bin/opam
-RUN opam install -y core core_unix http_async
+RUN (cd opam-repository && git pull origin 06c9f5470403fb40e7b3e8561ec60ac088817c7b && opam update)
+RUN opam install -y core core_unix http_async.0.1.0
 WORKDIR /src
 COPY --chown=opam . /src
 RUN sudo chown opam .


### PR DESCRIPTION
Updates cohttp-eio to use latest:
- mirage/ocaml-cohttp (master)
- eio (0.6)
- ocaml (5.1+trunk)

~~5.1.+trunk is not yet usable due to [luv issue #135](https://github.com/aantron/luv/issues/135)~~

Fixes #27 

/cc @shakthimaan 