### PR TITLE
fix(httpaf-effects): fix build error and runtime connection handling

### DIFF
--- a/httpaf-effects/httpaf_effects.ml
+++ b/httpaf-effects/httpaf_effects.ml
@@ -1,82 +1,66 @@
 open Httpaf
-module Write = Eio.Buf_write
 module EioFib = Eio.Fiber
-module Switch = Eio.Switch
 
-let debug = false
+let read_buffer_size = 10000
 
-exception Partial
-
-let read_buffer_size = max_int
+let write_iovecs fd iovecs =
+  let bufs =
+    List.map
+      (fun { Faraday.buffer; off; len } ->
+        Cstruct.sub (Cstruct.of_bigarray buffer) off len)
+      iovecs
+  in
+  Eio.Flow.write fd bufs;
+  List.fold_left (fun acc { Faraday.len; _ } -> acc + len) 0 iovecs
 
 let create_connection_handler ?config request_handler =
-  fun fd _ -> let conn = Server_connection.create ?config
-                  (fun request -> request_handler request) in
-    let buffer = Lwt_bytes.create read_buffer_size in
-    let buffer_len = ref 0 in
-      let rec reader_thread () =
-        match Server_connection.next_read_operation conn with
-        | `Read ->
-            begin
+  fun fd _addr ->
+    let conn = Server_connection.create ?config request_handler in
+    let read_buf = Cstruct.create read_buffer_size in
+    let read_bigstring = Cstruct.to_bigarray read_buf in
+    let buffered_bytes = ref 0 in
+    let rec reader_thread () =
+      match Server_connection.next_read_operation conn with
+      | `Read ->
+          begin
             try
-              let current_read_len =
-                Eio.Buf_read.buffered_bytes (Eio.Buf_read.of_buffer buffer)
-              in
-              buffer_len := !buffer_len + current_read_len;
-              if current_read_len = 0 then
-                begin
-                Server_connection.read_eof conn buffer ~off:0 ~len:!buffer_len |> ignore;
-                end
-              else
-                begin
-                    let bytes_consumed =
-                     Server_connection.read conn buffer ~off:0 ~len:!buffer_len in
-                     Bigstringaf.blit buffer ~src_off:bytes_consumed
-                                      buffer ~dst_off:0 ~len:(!buffer_len - bytes_consumed);
-                        buffer_len := !buffer_len - bytes_consumed
-                end
-            with _ -> ignore(Server_connection.read_eof conn buffer ~off:0 ~len:0)
-            end;
-            reader_thread ()
-        | `Yield       ->
-            (* let tid = if debug then Aeio.get_tid () else 0xC0FFEE in *)
-            let p, iv = Eio.Promise.create () in
-            Server_connection.yield_reader conn (fun () ->
-              Eio.Promise.resolve iv ());
-              Eio.Promise.await p;
+              let dst = Cstruct.sub read_buf !buffered_bytes (read_buffer_size - !buffered_bytes) in
+              let n_read = Eio.Flow.single_read fd dst in
+              let available = !buffered_bytes + n_read in
+              let consumed = Server_connection.read conn read_bigstring ~off:0 ~len:available in
+              let remaining = available - consumed in
+              if remaining > 0 then
+                Bigstringaf.blit read_bigstring ~src_off:consumed
+                  read_bigstring ~dst_off:0 ~len:remaining;
+              buffered_bytes := remaining;
               reader_thread ()
-        | `Close -> Eio.Flow.shutdown fd `Receive
-      in
-      let rec writer_thread () =
-        let success = Server_connection.report_write_result conn in
-        match Server_connection.next_write_operation conn with
-        | `Write iovecs ->
-          (* TODO: Aeio.writev *)
-         let written = ref 0 in
-          begin try
-            List.iter (fun {Faraday.buffer; off; len} ->
-               let w = Write.with_flow ~initial_size:len
-                   fd (fun buffer -> Write.drain buffer;)
-                in
-                written := !written + w;
-                if w < len then raise Partial) iovecs;
-              success (`Ok !written)
-          with
-          | Partial ->
-              success (`Ok !written)
-          | _ -> success `Closed
+            with
+            | End_of_file ->
+                ignore (Server_connection.read_eof conn read_bigstring ~off:0 ~len:!buffered_bytes);
+                buffered_bytes := 0;
+                reader_thread ()
+            | exn ->
+                Server_connection.report_exn conn exn;
+                Eio.Flow.shutdown fd `All
+          end
+      | `Yield -> Server_connection.yield_reader conn reader_thread
+      | `Close -> Eio.Flow.shutdown fd `Receive
+    in
+    let rec writer_thread () =
+      match Server_connection.next_write_operation conn with
+      | `Write iovecs ->
+          let report = Server_connection.report_write_result conn in
+          begin
+            try
+              let written = write_iovecs fd iovecs in
+              report (`Ok written)
+            with
+            | exn ->
+                Server_connection.report_exn conn exn;
+                report `Closed
           end;
           writer_thread ()
-        | `Yield        ->
-            (* let tid = if debug then Aeio.get_tid () else 0xC0FFEE in *)
-            let p, iv = Eio.Promise.create () in
-            Server_connection.yield_writer conn (fun () ->
-              Eio.Promise.resolve iv ());
-              Eio.Promise.await p;
-              writer_thread ()
-        | `Close _      -> Eio.Flow.shutdown fd `Send
-      in
-      ignore @@
-      EioFib.both
-        (fun () -> reader_thread () )
-        (fun () -> writer_thread () );
+      | `Yield -> Server_connection.yield_writer conn writer_thread
+      | `Close _ -> Eio.Flow.shutdown fd `Send
+    in
+    ignore @@ EioFib.both reader_thread writer_thread

--- a/httpaf-effects/wrk_effects_benchmark.ml
+++ b/httpaf-effects/wrk_effects_benchmark.ml
@@ -27,7 +27,7 @@ let traceln fmt = traceln ("server: " ^^ fmt)
 
 let handle_request flow addr =
   traceln "Server: About to set up connection handler";
-  create_connection_handler request_handler;
+  create_connection_handler request_handler flow addr;
   traceln "Server: copied data to client; connection closed"
 
 let server_run socket =


### PR DESCRIPTION
### Summary
This PR fixes the remaining httpaf-effects stability problems with minimal, focused changes.

- Fixes the partial application build failure in the benchmark handler path.
- Fixes connection I/O handling so requests are read and written correctly.
- Uses a bounded read buffer to avoid out-of-memory crashes.

### Result
- Build succeeds.
- Runtime no longer fails with prompt input shrunk, connection reset, or OOM for normal requests.
- Endpoint responds correctly to curl with HTTP 200.

### Issues
Fixes #35  
Fixes #36  
Fixes #37

Issue reference: https://github.com/ocaml-multicore/retro-httpaf-bench/issues/37