### PR TITLE
Fix errors in httpaf-effects, httpaf-eio and minor updates for deprecated functions

### DIFF
--- a/http-async/main.ml
+++ b/http-async/main.ml
@@ -30,15 +30,17 @@ let text =
    the well, and noticed that they were filled with cupboards......"
 ;;
 
-let service context request =
-    Deferred.return (Response.create ~body:(Body.string text) `Ok)
+let service _ _ =
+    let headers = Headers.of_list ["content-length", string_of_int (String.length text)] in
+    Deferred.return (Response.create ~headers ~body:(Body.string text) `Ok)
 
 let run port =
-        let server = Server.run_inet (Tcp.Where_to_listen.of_port port) service in
-        Deferred.forever () (fun () ->
-            let%map.Deferred () = after Time.Span.(of_sec 0.5) in
-            Log.Global.printf "Active connections: %d" (Tcp.Server.num_connections server));
-        Tcp.Server.close_finished_and_handlers_determined server
+  let server = Server.run_inet (Tcp.Where_to_listen.of_port port) service
+  in
+  Deferred.forever () (fun () ->
+    let%map () = after (Time_float.Span.of_sec 0.5) in
+    Log.Global.printf "Active connections: %d" (Tcp.Server.num_connections server));
+  Tcp.Server.close_finished_and_handlers_determined server
 
 let command =
   Command.async

--- a/httpaf-effects/httpaf_effects.ml
+++ b/httpaf-effects/httpaf_effects.ml
@@ -12,7 +12,7 @@ let read_buffer_size = 4096
 let create_connection_handler ?config request_handler =
   fun fd _ -> let conn = Server_connection.create ?config
                   (fun request -> request_handler request) in
-    let buffer = Lwt_bytes.create read_buffer_size in
+    let buffer = Bigstringaf.create read_buffer_size in
     let buffer_len = ref 0 in
       let rec reader_thread () =
         match Server_connection.next_read_operation conn with

--- a/httpaf-effects/httpaf_effects.ml
+++ b/httpaf-effects/httpaf_effects.ml
@@ -48,25 +48,22 @@ let create_connection_handler ?config request_handler =
         | `Close -> Eio.Flow.shutdown fd `Receive
       in
       let rec writer_thread () =
-        let success = Server_connection.report_write_result conn in
-        match Server_connection.next_write_operation conn with
-        | `Write iovecs ->
-          (* TODO: Aeio.writev *)
-         let written = ref 0 in
-          begin try
-            List.iter (fun {Faraday.buffer; off; len} ->
-               let w = Write.with_flow ~initial_size:len
-                   fd (fun buffer -> Write.drain buffer;)
-                in
-                written := !written + w;
-                if w < len then raise Partial) iovecs;
-              success (`Ok !written)
-          with
-          | Partial ->
-              success (`Ok !written)
-          | _ -> success `Closed
-          end;
-          writer_thread ()
+       match Server_connection.next_write_operation conn with
+       | `Write iovecs ->
+           let written = ref 0 in
+           begin
+             try
+               List.iter (fun {Faraday.buffer; off; len} ->
+                 Write.with_flow ~initial_size:len fd (fun buf ->
+                  let s = Bigstringaf.substring buffer ~off:off ~len:len in
+                  Write.string buf s);
+                 written := !written + len
+               ) iovecs;
+               Server_connection.report_write_result conn (`Ok !written)
+             with _ ->
+               Server_connection.report_write_result conn `Closed
+           end;
+           writer_thread ()
         | `Yield        ->
             (* let tid = if debug then Aeio.get_tid () else 0xC0FFEE in *)
             let p, iv = Eio.Promise.create () in

--- a/httpaf-effects/httpaf_effects.ml
+++ b/httpaf-effects/httpaf_effects.ml
@@ -3,10 +3,6 @@ module Write = Eio.Buf_write
 module EioFib = Eio.Fiber
 module Switch = Eio.Switch
 
-let debug = false
-
-exception Partial
-
 let read_buffer_size = 4096
 
 let create_connection_handler ?config request_handler =
@@ -17,27 +13,31 @@ let create_connection_handler ?config request_handler =
       let rec reader_thread () =
         match Server_connection.next_read_operation conn with
         | `Read ->
-            begin
+          let continue =
             try
-              let current_read_len =
-                Eio.Buf_read.buffered_bytes (Eio.Buf_read.of_buffer buffer)
-              in
-              buffer_len := !buffer_len + current_read_len;
-              if current_read_len = 0 then
-                begin
-                Server_connection.read_eof conn buffer ~off:0 ~len:!buffer_len |> ignore;
-                end
-              else
-                begin
-                    let bytes_consumed =
-                     Server_connection.read conn buffer ~off:0 ~len:!buffer_len in
-                     Bigstringaf.blit buffer ~src_off:bytes_consumed
-                                      buffer ~dst_off:0 ~len:(!buffer_len - bytes_consumed);
-                        buffer_len := !buffer_len - bytes_consumed
-                end
-            with _ -> ignore(Server_connection.read_eof conn buffer ~off:0 ~len:0)
-            end;
-            reader_thread ()
+               let current_read_len =
+                 Eio.Flow.single_read fd
+                 (Cstruct.of_bigarray buffer ~off:0 ~len:(Bigstringaf.length buffer))
+               in
+                 buffer_len := !buffer_len + current_read_len;
+               let bytes_consumed =
+                 Server_connection.read conn buffer ~off:0 ~len:!buffer_len in
+               let buffer_remaining = !buffer_len - bytes_consumed in
+               let tmp = Bytes.create buffer_remaining in
+                  Bigstringaf.blit_to_bytes buffer ~src_off:bytes_consumed tmp
+                            ~dst_off:0 ~len:buffer_remaining;
+                  Bigstringaf.blit_from_bytes tmp ~src_off:0 buffer
+                            ~dst_off:0 ~len:buffer_remaining;
+               buffer_len := buffer_remaining;
+               true
+            with
+             | End_of_file ->
+               ignore (Server_connection.read_eof conn buffer ~off:0 ~len:!buffer_len);
+               false
+             | _ -> ignore(Server_connection.read_eof conn buffer ~off:0 ~len:0);
+               false
+            in
+            if continue then reader_thread ()
         | `Yield       ->
             (* let tid = if debug then Aeio.get_tid () else 0xC0FFEE in *)
             let p, iv = Eio.Promise.create () in

--- a/httpaf-effects/httpaf_effects.ml
+++ b/httpaf-effects/httpaf_effects.ml
@@ -7,7 +7,7 @@ let debug = false
 
 exception Partial
 
-let read_buffer_size = max_int
+let read_buffer_size = 4096
 
 let create_connection_handler ?config request_handler =
   fun fd _ -> let conn = Server_connection.create ?config

--- a/httpaf-effects/httpaf_effects.ml
+++ b/httpaf-effects/httpaf_effects.ml
@@ -1,79 +1,66 @@
 open Httpaf
-module Write = Eio.Buf_write
 module EioFib = Eio.Fiber
-module Switch = Eio.Switch
 
-let read_buffer_size = 4096
+let read_buffer_size = 10000
+
+let write_iovecs fd iovecs =
+  let bufs =
+    List.map
+      (fun { Faraday.buffer; off; len } ->
+        Cstruct.sub (Cstruct.of_bigarray buffer) off len)
+      iovecs
+  in
+  Eio.Flow.write fd bufs;
+  List.fold_left (fun acc { Faraday.len; _ } -> acc + len) 0 iovecs
 
 let create_connection_handler ?config request_handler =
-  fun fd _ -> let conn = Server_connection.create ?config
-                  (fun request -> request_handler request) in
-    let buffer = Bigstringaf.create read_buffer_size in
-    let buffer_len = ref 0 in
-      let rec reader_thread () =
-        match Server_connection.next_read_operation conn with
-        | `Read ->
-          let continue =
+  fun fd _addr ->
+    let conn = Server_connection.create ?config request_handler in
+    let read_buf = Cstruct.create read_buffer_size in
+    let read_bigstring = Cstruct.to_bigarray read_buf in
+    let buffered_bytes = ref 0 in
+    let rec reader_thread () =
+      match Server_connection.next_read_operation conn with
+      | `Read ->
+          begin
             try
-               let current_read_len =
-                 Eio.Flow.single_read fd
-                 (Cstruct.of_bigarray buffer ~off:0 ~len:(Bigstringaf.length buffer))
-               in
-                 buffer_len := !buffer_len + current_read_len;
-               let bytes_consumed =
-                 Server_connection.read conn buffer ~off:0 ~len:!buffer_len in
-               let buffer_remaining = !buffer_len - bytes_consumed in
-               let tmp = Bytes.create buffer_remaining in
-                  Bigstringaf.blit_to_bytes buffer ~src_off:bytes_consumed tmp
-                            ~dst_off:0 ~len:buffer_remaining;
-                  Bigstringaf.blit_from_bytes tmp ~src_off:0 buffer
-                            ~dst_off:0 ~len:buffer_remaining;
-               buffer_len := buffer_remaining;
-               true
-            with
-             | End_of_file ->
-               ignore (Server_connection.read_eof conn buffer ~off:0 ~len:!buffer_len);
-               false
-             | _ -> ignore(Server_connection.read_eof conn buffer ~off:0 ~len:0);
-               false
-            in
-            if continue then reader_thread ()
-        | `Yield       ->
-            (* let tid = if debug then Aeio.get_tid () else 0xC0FFEE in *)
-            let p, iv = Eio.Promise.create () in
-            Server_connection.yield_reader conn (fun () ->
-              Eio.Promise.resolve iv ());
-              Eio.Promise.await p;
+              let dst = Cstruct.sub read_buf !buffered_bytes (read_buffer_size - !buffered_bytes) in
+              let n_read = Eio.Flow.single_read fd dst in
+              let available = !buffered_bytes + n_read in
+              let consumed = Server_connection.read conn read_bigstring ~off:0 ~len:available in
+              let remaining = available - consumed in
+              if remaining > 0 then
+                Bigstringaf.blit read_bigstring ~src_off:consumed
+                  read_bigstring ~dst_off:0 ~len:remaining;
+              buffered_bytes := remaining;
               reader_thread ()
-        | `Close -> Eio.Flow.shutdown fd `Receive
-      in
-      let rec writer_thread () =
-       match Server_connection.next_write_operation conn with
-       | `Write iovecs ->
-           let written = ref 0 in
-           begin
-             try
-               List.iter (fun {Faraday.buffer; off; len} ->
-                 Write.with_flow ~initial_size:len fd (fun buf ->
-                  let s = Bigstringaf.substring buffer ~off:off ~len:len in
-                  Write.string buf s);
-                 written := !written + len
-               ) iovecs;
-               Server_connection.report_write_result conn (`Ok !written)
-             with _ ->
-               Server_connection.report_write_result conn `Closed
-           end;
-           writer_thread ()
-        | `Yield        ->
-            (* let tid = if debug then Aeio.get_tid () else 0xC0FFEE in *)
-            let p, iv = Eio.Promise.create () in
-            Server_connection.yield_writer conn (fun () ->
-              Eio.Promise.resolve iv ());
-              Eio.Promise.await p;
-              writer_thread ()
-        | `Close _      -> Eio.Flow.shutdown fd `Send
-      in
-      ignore @@
-      EioFib.both
-        (fun () -> reader_thread () )
-        (fun () -> writer_thread () );
+            with
+            | End_of_file ->
+                ignore (Server_connection.read_eof conn read_bigstring ~off:0 ~len:!buffered_bytes);
+                buffered_bytes := 0;
+                reader_thread ()
+            | exn ->
+                Server_connection.report_exn conn exn;
+                Eio.Flow.shutdown fd `All
+          end
+      | `Yield -> Server_connection.yield_reader conn reader_thread
+      | `Close -> Eio.Flow.shutdown fd `Receive
+    in
+    let rec writer_thread () =
+      match Server_connection.next_write_operation conn with
+      | `Write iovecs ->
+          let report = Server_connection.report_write_result conn in
+          begin
+            try
+              let written = write_iovecs fd iovecs in
+              report (`Ok written)
+            with
+            | exn ->
+                Server_connection.report_exn conn exn;
+                report `Closed
+          end;
+          writer_thread ()
+      | `Yield -> Server_connection.yield_writer conn writer_thread
+      | `Close _ -> Eio.Flow.shutdown fd `Send
+    in
+    ignore @@ EioFib.both reader_thread writer_thread

--- a/httpaf-effects/wrk_effects_benchmark.ml
+++ b/httpaf-effects/wrk_effects_benchmark.ml
@@ -1,5 +1,4 @@
 open Eio
-open Eio.Resource
 open Httpaf
 open Httpaf_effects
 module Read = Eio.Buf_read
@@ -27,12 +26,12 @@ let traceln fmt = traceln ("server: " ^^ fmt)
 
 let handle_request flow addr =
   traceln "Server: About to set up connection handler";
-  create_connection_handler request_handler;
+  (create_connection_handler request_handler) flow addr;
   traceln "Server: copied data to client; connection closed"
 
 let server_run socket =
    Eio.Net.run_server socket handle_request
-    ~on_error:(traceln "Error handling connection: %a" Fmt.exn)
+    ~on_error:(fun e -> traceln "Error handling connection: %a" Fmt.exn e)
     ~max_connections:1000
 
 let addr = `Tcp (Eio.Net.Ipaddr.V4.loopback, 8080)
@@ -40,6 +39,6 @@ let addr = `Tcp (Eio.Net.Ipaddr.V4.loopback, 8080)
 let () =
   Eio_main.run @@ fun env ->
   let net = Eio.Stdenv.net env in
-  Switch.run ~name:"main" @@ fun sw ->
+  Switch.run @@ fun sw ->
   let listening_socket = Eio.Net.listen net ~sw ~reuse_addr:true ~backlog:10 addr in
   Fiber.fork ~sw (fun () -> server_run listening_socket);

--- a/httpaf-eio/dune
+++ b/httpaf-eio/dune
@@ -1,3 +1,3 @@
 (executable
  (name wrk_effects_benchmark)
- (libraries eio_main httpaf eio faraday angstrom logs.fmt))
+ (libraries eio_main httpaf eio faraday angstrom logs.fmt eio_linux))

--- a/httpaf-eio/httpaf_eio.ml
+++ b/httpaf-eio/httpaf_eio.ml
@@ -1,0 +1,82 @@
+open Httpaf
+module Write = Eio.Buf_write
+module EioFib = Eio.Fiber
+module Switch = Eio.Switch
+
+let debug = false
+
+exception Partial
+
+let read_buffer_size = 4096
+
+let handle_connection conn fd _ =
+    let buffer = Bigstringaf.create read_buffer_size in
+    let buffer_len = ref 0 in
+
+      let rec reader_thread () =
+        match Server_connection.next_read_operation conn with
+        | `Read ->
+          let current_read_len =
+                Eio.Flow.single_read fd
+                (Cstruct.of_bigarray buffer ~off:0 ~len:(Bigstringaf.length buffer))
+          in
+          let continue =
+            try
+                buffer_len := !buffer_len + current_read_len;
+                let bytes_consumed =
+                  Server_connection.read conn buffer ~off:0 ~len:!buffer_len in
+                let buffer_remaining = !buffer_len - bytes_consumed in
+                let tmp = Bytes.create buffer_remaining in
+                       Bigstringaf.blit_to_bytes buffer ~src_off:bytes_consumed tmp
+                                 ~dst_off:0 ~len:buffer_remaining;
+                        Bigstringaf.blit_from_bytes tmp ~src_off:0 buffer
+                                 ~dst_off:0 ~len:buffer_remaining;
+                  buffer_len := buffer_remaining;
+                  true
+            with
+             | End_of_file ->
+               ignore (Server_connection.read_eof conn buffer ~off:0 ~len:!buffer_len);
+               false
+             | _ -> ignore(Server_connection.read_eof conn buffer ~off:0 ~len:0);
+                false
+            in
+            if continue then reader_thread ()
+        | `Yield       ->
+            (* let tid = if debug then Aeio.get_tid () else 0xC0FFEE in *)
+            let p, iv = Eio.Promise.create () in
+            Server_connection.yield_reader conn (fun () ->
+              Eio.Promise.resolve iv ());
+              Eio.Promise.await p;
+              reader_thread ()
+        | `Close -> Eio.Flow.shutdown fd `Receive
+      in
+      let rec writer_thread () =
+       match Server_connection.next_write_operation conn with
+       | `Write iovecs ->
+           let written = ref 0 in
+           begin
+             try
+               List.iter (fun {Faraday.buffer; off; len} ->
+                 Write.with_flow ~initial_size:len fd (fun buf ->
+                  let s = Bigstringaf.substring buffer ~off:off ~len:len in
+                  Write.string buf s);
+                 written := !written + len
+               ) iovecs;
+               Server_connection.report_write_result conn (`Ok !written)
+             with _ ->
+               Server_connection.report_write_result conn `Closed
+           end;
+           writer_thread ()
+        | `Yield        ->
+            (* let tid = if debug then Aeio.get_tid () else 0xC0FFEE in *)
+            let p, iv = Eio.Promise.create () in
+            Server_connection.yield_writer conn (fun () ->
+              Eio.Promise.resolve iv ());
+              Eio.Promise.await p;
+              writer_thread ()
+        | `Close _      -> Eio.Flow.shutdown fd `Send
+      in
+      ignore @@
+      EioFib.both
+        (fun () -> reader_thread () )
+        (fun () -> writer_thread () );

--- a/httpaf-eio/wrk_effects_benchmark.ml
+++ b/httpaf-eio/wrk_effects_benchmark.ml
@@ -48,7 +48,7 @@ let run_domain ssock =
     let flow, addr = Eio.Net.accept ssock ~sw in
     Fiber.fork ~sw (fun () ->
       match create_connection_handler ~error_handler request_handler flow addr with
-      | () -> ()
+      | _  -> ()
       | exception ex -> log_connection_error ex)
   done
 

--- a/httpaf-eio/wrk_effects_benchmark.ml
+++ b/httpaf-eio/wrk_effects_benchmark.ml
@@ -1,11 +1,13 @@
 open Httpaf
 open Eio.Std
+open Httpaf_eio
 
 let text = "CHAPTER I. Down the Rabbit-Hole  Alice was beginning to get very tired of sitting by her sister on the bank, and of having nothing to do: once or twice she had peeped into the book her sister was reading, but it had no pictures or conversations in it, <and what is the use of a book,> thought Alice <without pictures or conversations?> So she was considering in her own mind (as well as she could, for the hot day made her feel very sleepy and stupid), whether the pleasure of making a daisy-chain would be worth the trouble of getting up and picking the daisies, when suddenly a White Rabbit with pink eyes ran close by her. There was nothing so very remarkable in that; nor did Alice think it so very much out of the way to hear the Rabbit say to itself, <Oh dear! Oh dear! I shall be late!> (when she thought it over afterwards, it occurred to her that she ought to have wondered at this, but at the time it all seemed quite natural); but when the Rabbit actually took a watch out of its waistcoat-pocket, and looked at it, and then hurried on, Alice started to her feet, for it flashed across her mind that she had never before seen a rabbit with either a waistcoat-pocket, or a watch to take out of it, and burning with curiosity, she ran across the field after it, and fortunately was just in time to see it pop down a large rabbit-hole under the hedge. In another moment down went Alice after it, never once considering how in the world she was to get out again. The rabbit-hole went straight on like a tunnel for some way, and then dipped suddenly down, so suddenly that Alice had not a moment to think about stopping herself before she found herself falling down a very deep well. Either the well was very deep, or she fell very slowly, for she had plenty of time as she went down to look about her and to wonder what was going to happen next. First, she tried to look down and make out what she was coming to, but it was too dark to see anything; then she looked at the sides of the well, and noticed that they were filled with cupboards......"
 
 let text = Bigstringaf.of_string ~off:0 ~len:(String.length text) text
 
 let headers = Headers.of_list ["content-length", string_of_int (Bigstringaf.length text)]
+
 let request_handler _ reqd =
   let request = Reqd.request reqd in
   match request.target with
@@ -20,12 +22,12 @@ let request_handler _ reqd =
     let response_nf = Response.create ~headers `Not_found in
     Reqd.respond_with_string reqd response_nf msg
 
-let error_handler _ ?request:_ error start_response =
+let error_handler ?request:_ error start_response =
   let response_body = start_response Httpaf.Headers.empty in
   begin match error with
   | `Exn exn ->
     Httpaf.Body.write_string response_body (Printexc.to_string exn);
-    Httpaf.Body.write_string response_body "\n";
+    Httpaf.Body.write_string response_body "\n"
   | #Httpaf.Status.standard as error ->
     Httpaf.Body.write_string response_body (Httpaf.Status.default_reason_phrase error)
   end;
@@ -34,19 +36,26 @@ let error_handler _ ?request:_ error start_response =
 let log_connection_error ex =
   traceln "Uncaught exception handling client: %a" Fmt.exn ex
 
+let create_connection_handler ~error_handler request_handler fd addr =
+  let conn = Server_connection.create ~error_handler
+               (fun reqd -> request_handler addr reqd) in
+  handle_connection conn fd
+
 let run_domain ssock =
   traceln "Running server in domain %d" (Domain.self () :> int);
   Switch.run @@ fun sw ->
-  let handle_connection = Server_connection.create (fun req -> request_handler
-                                                       () req) in
-  (* Wait for clients, and fork off echo servers. *)
   while true do
-    Eio.Net.accept ssock ~sw
+    let flow, addr = Eio.Net.accept ssock ~sw in
+    Fiber.fork ~sw (fun () ->
+      match create_connection_handler ~error_handler request_handler flow addr with
+      | () -> ()
+      | exception ex -> log_connection_error ex)
   done
 
 let main ~net ~domain_mgr ~n_domains port backlog =
   Switch.run @@ fun sw ->
-  let ssock = Eio.Net.listen net ~sw ~reuse_addr:true ~backlog @@ `Tcp (Eio.Net.Ipaddr.V4.loopback, port) in
+  let ssock = Eio.Net.listen net ~sw ~reuse_addr:true ~backlog
+                             @@ `Tcp (Eio.Net.Ipaddr.V4.loopback, port) in
   traceln "Echo server listening on 127.0.0.1:%d" port;
   traceln "Starting %d domains..." n_domains;
   for _ = 2 to n_domains do
@@ -69,16 +78,6 @@ let polling_timeout =
   )
 
 let () =
-(*
-  Logs.(set_level (Some Debug));
-  Logs.set_reporter (Logs_fmt.reporter ());
-*)
-(*
-  let buffer = Ctf.Unix.mmap_buffer ~size:0x100000 "trace/trace.ctf" in
-  let trace_config = Ctf.Control.make buffer in
-  Ctf.Control.start trace_config;
-*)
-  (* Eio_luv.run @@ fun env -> *)
   Eio_linux.run ~queue_depth:2048 ?polling_timeout @@ fun env ->
   let n_domains =
     match Sys.getenv_opt "HTTPAF_EIO_DOMAINS" with

--- a/httpaf-lwt/httpaf_lwt.ml
+++ b/httpaf-lwt/httpaf_lwt.ml
@@ -18,7 +18,7 @@ module BenchmarkServer = struct
       Lwt.pause () >>= fun () ->
       (match target with
       | "/" -> Reqd.respond_with_bigstring reqd (Response.create ~headers `OK) text;
-      | "/exit" -> exit 0;
+      | "/exit" -> Stdlib.exit 0;
       | _   -> Reqd.respond_with_string    reqd (Response.create `Not_found) "Route not found");
       Lwt.return_unit
     in
@@ -57,8 +57,8 @@ let main port =
 
 let () =
   let port = ref 8080 in
-  Arg.parse
-    ["-p", Arg.Set_int port, " Listening port number (8080 by default)"]
+  Stdlib.Arg.parse
+    ["-p", Stdlib.Arg.Set_int port, " Listening port number (8080 by default)"]
     ignore
     "Responds to requests with a fixed string for benchmarking purposes.";
   main !port


### PR DESCRIPTION
The PR fixes:

- size for `read_buffer_size`, functions `next_read_operation`, `next_write_operation` in `httpaf-effects`
- corrections for the benchmarking script in `httpaf-effects`
- functions `handle_connection` in `httpaf-eio` as well as corrections in the benchmarking script for it
- adds a missing library (`eio_linux`) for `httpaf-eio`
- minor updates for deprecated library functions in `http-async`, `httpaf-lwt`
